### PR TITLE
fix to prevent opening multiple detailviews at the same time

### DIFF
--- a/Pantad/app/src/main/java/com/example/pantad/AdListUtils/AbstractAdapter.java
+++ b/Pantad/app/src/main/java/com/example/pantad/AdListUtils/AbstractAdapter.java
@@ -111,28 +111,28 @@ public abstract class AbstractAdapter extends RecyclerView.Adapter implements Pr
 
             viewHolder.itemView.setOnClickListener(new View.OnClickListener() {
                 public void onClick(View v) {
-
-                    upm.updateViewingProfile(ad.getDonatorID());
                     // Create the item details window
                     final ItemDetailsWindow itemDetails=createItemListener(ad,v);
+                    if (itemDetails != null) {
+                        upm.updateViewingProfile(ad.getDonatorID());
+                        // Dim the background
+                        View container = itemDetails.getContentView().getRootView();
+                        Context context = itemDetails.getContentView().getContext();
 
-                    // Dim the background
-                    View container = itemDetails.getContentView().getRootView();
-                    Context context = itemDetails.getContentView().getContext();
-
-                    WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-                    WindowManager.LayoutParams params = (WindowManager.LayoutParams) container.getLayoutParams();
-                    params.flags |= WindowManager.LayoutParams.FLAG_DIM_BEHIND;
-                    params.dimAmount = 0.4f;
-                    wm.updateViewLayout(container, params);
+                        WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+                        WindowManager.LayoutParams params = (WindowManager.LayoutParams) container.getLayoutParams();
+                        params.flags |= WindowManager.LayoutParams.FLAG_DIM_BEHIND;
+                        params.dimAmount = 0.4f;
+                        wm.updateViewLayout(container, params);
 
 
-                    // Create and connect listener to cancel button
-                    itemDetails.cancelButton.setOnClickListener(new View.OnClickListener() {
-                        public void onClick(View v) {
-                            itemDetails.dismiss();
-                        }
-                    });
+                        // Create and connect listener to cancel button
+                        /*itemDetails.cancelButton.setOnClickListener(new View.OnClickListener() {
+                            public void onClick(View v) {
+                                itemDetails.dismiss();
+                            }
+                        });*/
+                    }
 
 
                 }

--- a/Pantad/app/src/main/java/com/example/pantad/AdListUtils/ItemDetailsWindow.java
+++ b/Pantad/app/src/main/java/com/example/pantad/AdListUtils/ItemDetailsWindow.java
@@ -29,8 +29,11 @@ public abstract class ItemDetailsWindow extends PopupWindow implements PropertyC
     public final View parent;
     public ImageView userAvatar;
     private UserProfileModel upm;
+    //making sure only one detailview can be open, fix for the problem with pressing on two ads with 2 different fingers opening two detailviews.
+    private static boolean open = false;
 
     public ItemDetailsWindow(final View parent, final Ad ad, UserProfileModel upm, UserModel userModel) {
+        open = true;
         this.ad=ad;
         this.userModel=userModel;
         this.parent=parent;
@@ -71,9 +74,21 @@ public abstract class ItemDetailsWindow extends PopupWindow implements PropertyC
 
     @Override
     public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
-        if (userAvatar == null){
+        if (upm.getViewingProfile() == null){
             return;
         }
         ImageLoader.loadImageFromUrl(upm.getViewingPhotoUrl(), userAvatar);
     }
+
+    @Override
+    public void dismiss(){
+        open = false;
+        super.dismiss();
+    }
+
+    public static boolean canOpenDetalView(){
+        return !open;
+    }
+
+
 }

--- a/Pantad/app/src/main/java/com/example/pantad/AdListUtils/MyPostingsAdapter.java
+++ b/Pantad/app/src/main/java/com/example/pantad/AdListUtils/MyPostingsAdapter.java
@@ -37,7 +37,9 @@ public class MyPostingsAdapter extends AbstractAdapter {
 
     @Override
     protected ItemDetailsWindow createItemListener(final Ad ad, final View v) {
-
+        if (!ItemDetailsWindow.canOpenDetalView()){
+            return null;
+        }
         final ItemDetailsWindow itemDetails = new MyPostingsDetailsWindow(v, ad,upm,userModel);
         itemDetails.showAtLocation(v, Gravity.CENTER, 0, 0);
         return itemDetails;

--- a/Pantad/app/src/main/java/com/example/pantad/AdListUtils/PickupAdapter.java
+++ b/Pantad/app/src/main/java/com/example/pantad/AdListUtils/PickupAdapter.java
@@ -33,6 +33,9 @@ public class PickupAdapter extends AbstractAdapter {
 
     @Override
     protected ItemDetailsWindow createItemListener(final Ad ad, View v) {
+        if (!ItemDetailsWindow.canOpenDetalView()){
+            return null;
+        }
         final ItemDetailsWindow itemDetails = new PickupDetailsWindow(v, ad, upm,userModel);
         itemDetails.showAtLocation(v, Gravity.CENTER, 0, 0);
 

--- a/Pantad/app/src/main/java/com/example/pantad/MapFragment.java
+++ b/Pantad/app/src/main/java/com/example/pantad/MapFragment.java
@@ -163,6 +163,9 @@ public class MapFragment extends Fragment implements OnMapReadyCallback, Propert
 
     //TODO: This is copy pasted from pickupfragment, can probably make this more abstract
     protected void createItemListener(final Ad ad, View v) {
+        if (!ItemDetailsWindow.canOpenDetalView()){
+            return;
+        }
         final ItemDetailsWindow itemDetails = new PickupDetailsWindow(v, ad,upm,userModel);
         upm.updateViewingProfile(ad.getDonatorID());
         itemDetails.showAtLocation(v, Gravity.CENTER, 0, 0);


### PR DESCRIPTION
There was an issue where you could click on multiple ads at the same time by using multiple fingers and having it open more than one detailview